### PR TITLE
feat: integrate credentials authentication with NextAuth

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from "@/auth";

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import bcrypt from "bcrypt";
+import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+export async function POST(req: Request): Promise<Response> {
+  try {
+    const { email, password, name } = await req.json();
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: "Email and password are required" },
+        { status: 400 },
+      );
+    }
+
+    const existingUser = await db.query.users.findFirst({
+      where: eq(users.email, email),
+    });
+    if (existingUser) {
+      return NextResponse.json(
+        { error: "Email already registered" },
+        { status: 400 },
+      );
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    await db.insert(users).values({
+      id: randomUUID(),
+      email,
+      name,
+      password: hashed,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Registration error", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
+
+export default function LoginPage(): JSX.Element {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const result = await signIn("credentials", {
+      redirect: false,
+      email,
+      password,
+    });
+    if (result?.error) {
+      setError("Invalid email or password");
+      return;
+    }
+    router.push("/dashboard");
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 p-4">
+      <div>
+        <label htmlFor="email" className="block">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+      </div>
+      <div>
+        <label htmlFor="password" className="block">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+      </div>
+      {error && <p className="text-red-500">{error}</p>}
+      <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">
+        Sign In
+      </button>
+    </form>
+  );
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function RegisterPage(): JSX.Element {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const response = await fetch("/api/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, email, password }),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      setError(data.error ?? "Registration failed");
+      return;
+    }
+    router.push("/login");
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4 p-4">
+      <div>
+        <label htmlFor="name" className="block">
+          Name
+        </label>
+        <input
+          id="name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2"
+          required
+        />
+      </div>
+      <div>
+        <label htmlFor="email" className="block">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+      </div>
+      <div>
+        <label htmlFor="password" className="block">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+      </div>
+      {error && <p className="text-red-500">{error}</p>}
+      <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">
+        Register
+      </button>
+    </form>
+  );
+}

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,50 @@
+import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import type { NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcrypt";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+export const authConfig = {
+  adapter: DrizzleAdapter(db),
+  session: { strategy: "database" },
+  pages: { signIn: "/login" },
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "text" },
+        password: { label: "Password", type: "password" },
+      },
+      authorize: async (credentials) => {
+        if (!credentials?.email || !credentials.password) {
+          return null;
+        }
+        const user = await db.query.users.findFirst({
+          where: eq(users.email, credentials.email),
+        });
+        if (!user || !user.password) {
+          return null;
+        }
+        const isValid = await bcrypt.compare(
+          credentials.password,
+          user.password,
+        );
+        if (!isValid) {
+          return null;
+        }
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          image: user.image,
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    authorized({ auth }) {
+      return !!auth?.user;
+    },
+  },
+} satisfies NextAuthConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,5 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+export const { handlers: { GET, POST }, auth, signIn, signOut } =
+  NextAuth(authConfig);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,49 +1,108 @@
 import {
-    pgTable,
-    serial,
-    text,
-    varchar,
-    integer,
-    decimal,
-    date,
-    timestamp,
-    index,
-    uniqueIndex,
-  } from 'drizzle-orm/pg-core';
-  
-  // --- User Table ---
-  export const users = pgTable('users', {
-    id: serial('id').primaryKey(),
-    email: text('email').notNull().unique(),
-    hashedPassword: text('hashed_password').notNull(),
-    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  });
-  
-  // --- Product Table ---
-  export const products = pgTable('products', {
-    id: serial('id').primaryKey(),
-    productCode: varchar('product_code', { length: 50 }).notNull().unique(),
-    name: varchar('name', { length: 255 }).notNull(),
-  });
-  
-  // --- Daily Record Table ---
-  export const dailyRecords = pgTable('daily_records', {
-    id: serial('id').primaryKey(),
-    productId: integer('product_id').notNull().references(() => products.id, { onDelete: 'cascade' }),
-    recordDate: date('record_date').notNull(),
-    openingInventory: integer('opening_inventory').notNull(), 
-    procurementQty: integer('procurement_qty').notNull(),
-    procurementPrice: decimal('procurement_price', { precision: 10, scale: 2 }).notNull(),
-    salesQty: integer('sales_qty').notNull(),
-    salesPrice: decimal('sales_price', { precision: 10, scale: 2 }).notNull(),
-    closingInventory: integer('closing_inventory').notNull(),// Although it can be calculated, explicit storage can improve query performance
-  }, (table) => {
-    return {
-      // Composite index for product and date, which can improve query performance
-      productDateIdx: index("product_date_idx").on(table.productId, table.recordDate),
-  
-      // This constraint ensures that "one product can only have one record per day"
-      // It prevents data pollution caused by program bugs or repeated uploads
-      productDateUnique: uniqueIndex("product_date_unique").on(table.productId, table.recordDate),
-    };
-  });
+  pgTable,
+  serial,
+  text,
+  varchar,
+  integer,
+  decimal,
+  date,
+  timestamp,
+  index,
+  uniqueIndex,
+  primaryKey,
+} from "drizzle-orm/pg-core";
+import type { AdapterAccount } from "@auth/core/adapters";
+
+export const users = pgTable("user", {
+  id: text("id").notNull().primaryKey(),
+  name: text("name"),
+  email: text("email").notNull().unique(),
+  emailVerified: timestamp("emailVerified", { mode: "date" }),
+  image: text("image"),
+  password: text("password"),
+});
+
+export const accounts = pgTable(
+  "account",
+  {
+    userId: text("userId")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: text("type").$type<AdapterAccount["type"]>().notNull(),
+    provider: text("provider").notNull(),
+    providerAccountId: text("providerAccountId").notNull(),
+    refresh_token: text("refresh_token"),
+    access_token: text("access_token"),
+    expires_at: integer("expires_at"),
+    token_type: text("token_type"),
+    scope: text("scope"),
+    id_token: text("id_token"),
+    session_state: text("session_state"),
+  },
+  (account) => ({
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
+  }),
+);
+
+export const sessions = pgTable("session", {
+  sessionToken: text("sessionToken").notNull().primaryKey(),
+  userId: text("userId")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  expires: timestamp("expires", { mode: "date" }).notNull(),
+});
+
+export const verificationTokens = pgTable(
+  "verificationToken",
+  {
+    identifier: text("identifier").notNull(),
+    token: text("token").notNull(),
+    expires: timestamp("expires", { mode: "date" }).notNull(),
+  },
+  (vt) => ({
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
+  }),
+);
+
+// --- Product Table ---
+export const products = pgTable("products", {
+  id: serial("id").primaryKey(),
+  productCode: varchar("product_code", { length: 50 }).notNull().unique(),
+  name: varchar("name", { length: 255 }).notNull(),
+});
+
+// --- Daily Record Table ---
+export const dailyRecords = pgTable(
+  "daily_records",
+  {
+    id: serial("id").primaryKey(),
+    productId: integer("product_id")
+      .notNull()
+      .references(() => products.id, { onDelete: "cascade" }),
+    recordDate: date("record_date").notNull(),
+    openingInventory: integer("opening_inventory").notNull(),
+    procurementQty: integer("procurement_qty").notNull(),
+    procurementPrice: decimal("procurement_price", {
+      precision: 10,
+      scale: 2,
+    }).notNull(),
+    salesQty: integer("sales_qty").notNull(),
+    salesPrice: decimal("sales_price", {
+      precision: 10,
+      scale: 2,
+    }).notNull(),
+    closingInventory: integer("closing_inventory").notNull(),
+  },
+  (table) => ({
+    productDateIdx: index("product_date_idx").on(
+      table.productId,
+      table.recordDate,
+    ),
+    productDateUnique: uniqueIndex("product_date_unique").on(
+      table.productId,
+      table.recordDate,
+    ),
+  }),
+);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,8 @@
+import NextAuth from "next-auth";
+import { authConfig } from "./auth.config";
+
+export default NextAuth(authConfig).auth;
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/upload/:path*"],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "drizzle-orm": "^0.44.5",
         "lucide-react": "^0.542.0",
         "next": "15.5.2",
-        "next-auth": "^4.24.7",
+        "next-auth": "5.0.0-beta.29",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^3.1.2",
@@ -63,16 +63,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@auth/drizzle-adapter": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.10.0.tgz",
-      "integrity": "sha512-3MKsdAINTfvV4QKev8PFMNG93HJEUHh9sggDXnmUmriFogRf8qLvgqnPsTlfUyWcLwTzzrrYjeu8CGM+4IxHwQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@auth/core": "0.40.0"
-      }
-    },
-    "node_modules/@auth/drizzle-adapter/node_modules/@auth/core": {
+    "node_modules/@auth/core": {
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.40.0.tgz",
       "integrity": "sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==",
@@ -101,40 +92,13 @@
         }
       }
     },
-    "node_modules/@auth/drizzle-adapter/node_modules/jose": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
-      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@auth/drizzle-adapter/node_modules/oauth4webapi": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.0.tgz",
-      "integrity": "sha512-RSu64fjsBIs6D7s9g5LOCnOohOkI0nnPtlIp/4rrHj2Vb8jGepq+fujkv2Srw4tuw9qa02aETXQzyQUle8nfnQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/@auth/drizzle-adapter/node_modules/preact-render-to-string": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
-      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "preact": ">=10"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
+    "node_modules/@auth/drizzle-adapter": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@auth/drizzle-adapter/-/drizzle-adapter-1.10.0.tgz",
+      "integrity": "sha512-3MKsdAINTfvV4QKev8PFMNG93HJEUHh9sggDXnmUmriFogRf8qLvgqnPsTlfUyWcLwTzzrrYjeu8CGM+4IxHwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.40.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -4448,15 +4412,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6639,9 +6594,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -7043,24 +6998,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/lru-cache/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/lucide-react": {
       "version": "0.542.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
@@ -7287,30 +7224,25 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.11",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
-      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "version": "5.0.0-beta.29",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.29.tgz",
+      "integrity": "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A==",
       "license": "ISC",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.0",
-        "jose": "^4.15.5",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
+        "@auth/core": "0.40.0"
       },
       "peerDependencies": {
-        "@auth/core": "0.34.2",
-        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0-0",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "react": "^18.2.0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
-        "@auth/core": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
           "optional": true
         },
         "nodemailer": {
@@ -7366,11 +7298,14 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "license": "MIT"
+    "node_modules/oauth4webapi": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.1.tgz",
+      "integrity": "sha512-olkZDELNycOWQf9LrsELFq8n05LwJgV8UkrS0cburk6FOwf8GvLam+YB+Uj5Qvryee+vwWOfQVeI5Vm0MVg7SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7380,15 +7315,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -7509,30 +7435,6 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "license": "MIT"
-    },
-    "node_modules/oidc-token-hash": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
-      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
-    "node_modules/openid-client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -7815,13 +7717,10 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
-      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
       "license": "MIT",
-      "dependencies": {
-        "pretty-format": "^3.8.0"
-      },
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -7835,12 +7734,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -9236,15 +9129,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "drizzle-orm": "^0.44.5",
     "lucide-react": "^0.542.0",
     "next": "15.5.2",
-    "next-auth": "^4.24.7",
+    "next-auth": "5.0.0-beta.29",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^3.1.2",

--- a/test/api/upload.test.ts
+++ b/test/api/upload.test.ts
@@ -3,17 +3,9 @@ import { NextRequest } from 'next/server';
 import { POST } from '../../app/api/upload/route';
 import { getTestDb, setupTestDb, cleanupTestDb } from '../setup';
 import { products, dailyRecords } from '../../lib/db/schema';
-import { eq } from 'drizzle-orm';
 import fs from 'fs';
 import path from 'path';
 
-// Mock Next.js response
-const createMockResponse = (data: any, status = 200) => {
-  return {
-    json: () => Promise.resolve(data),
-    status,
-  } as any;
-};
 
 describe('/api/upload', () => {
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
- integrate NextAuth credentials provider with Drizzle adapter and session strategy
- add registration endpoint and login/register pages
- protect dashboard and upload routes with authentication middleware

## Testing
- `npm run lint`
- `npm test` *(fails: missing postgres connection string)*
- `NEXTAUTH_SECRET=test POSTGRES_URL=postgres://user:pass@localhost:5432/db npm run build` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b265f990d8832d824f22963334daae